### PR TITLE
Ignore synthetic fields in reflection

### DIFF
--- a/src/main/java/com/rethinkdb/response/DBResponseMapper.java
+++ b/src/main/java/com/rethinkdb/response/DBResponseMapper.java
@@ -129,6 +129,8 @@ public class DBResponseMapper {
      */
     public static <T> T populateObject(T to, Map<String,Object> from) {
         for (Field field : to.getClass().getDeclaredFields()) {
+            if (field.isSynthetic()) continue;
+
             try {
                 field.setAccessible(true);
 


### PR DESCRIPTION
Synthetic fields are compiler-generated implementation artifacts that should not be reflected. This was causing errors for me when running tests with JaCoCo switched on—c.f. http://www.eclemma.org/jacoco/trunk/doc/faq.html ("My code uses reflection. Why does it fail when I execute it with JaCoCo?")
